### PR TITLE
add updated_at and sort by updated_at instead of created_at

### DIFF
--- a/mq-surreal/README.md
+++ b/mq-surreal/README.md
@@ -7,6 +7,7 @@
 ```sql
 DEFINE TABLE queue SCHEMAFULL;
 DEFINE FIELD created_at     ON queue TYPE datetime    ASSERT $value != NONE;
+DEFINE FIELD updated_at     ON queue TYPE datetime    ASSERT $value != NONE;
 DEFINE FIELD scheduled_at   ON queue TYPE datetime    ASSERT $value != NONE;
 DEFINE FIELD locked_at      ON queue TYPE datetime;
 DEFINE FIELD queue          ON queue TYPE string      ASSERT $value != NONE;

--- a/mq-surreal/src/producer.rs
+++ b/mq-surreal/src/producer.rs
@@ -27,7 +27,8 @@ impl Producer for SurrealProducer {
         self.db
             .query(
                 r#"CREATE type::thing($table, $id)
-                SET created_at=$created_at,
+                SET created_at=$now,
+                    updated_at=$now,
                     scheduled_at=$scheduled_at,
                     queue=$queue,
                     kind=$kind,
@@ -42,7 +43,7 @@ impl Producer for SurrealProducer {
             .bind(("queue", job.queue()))
             .bind(("kind", job.kind()))
             .bind(("payload", job.payload()))
-            .bind(("created_at", OffsetDateTime::now_utc()))
+            .bind(("now", OffsetDateTime::now_utc()))
             .bind((
                 "scheduled_at",
                 job.scheduled_at()

--- a/mq/src/job.rs
+++ b/mq/src/job.rs
@@ -14,6 +14,8 @@ pub struct Job {
     #[serde(with = "time::serde::iso8601::option")]
     created_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::iso8601::option")]
+    updated_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::iso8601::option")]
     scheduled_at: Option<OffsetDateTime>,
     pub(crate) payload: Value,
     error_reason: Option<Value>,
@@ -36,6 +38,7 @@ impl Job {
             payload: payload.into(),
             error_reason: None,
             created_at: None,
+            updated_at: None,
             scheduled_at: None,
             attempts: 0,
             max_attempts: 3,
@@ -72,6 +75,10 @@ impl Job {
 
     pub fn created_at(&self) -> &Option<OffsetDateTime> {
         &self.created_at
+    }
+
+    pub fn updated_at(&self) -> &Option<OffsetDateTime> {
+        &self.updated_at
     }
 
     pub fn payload(&self) -> &Value {


### PR DESCRIPTION
This allows failed jobs to be scheduled later.