### PR TITLE
add support for unique_key

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<()> {
         r#"
     DEFINE TABLE {table} SCHEMAFULL;
     DEFINE FIELD created_at     ON {table} TYPE datetime    ASSERT $value != NONE;
+    DEFINE FIELD updated_at     ON {table} TYPE datetime    ASSERT $value != NONE;
     DEFINE FIELD scheduled_at   ON {table} TYPE datetime    ASSERT $value != NONE;
     DEFINE FIELD locked_at      ON {table} TYPE datetime;
     DEFINE FIELD queue          ON {table} TYPE string      ASSERT $value != NONE;
@@ -42,6 +43,7 @@ async fn main() -> Result<()> {
     DEFINE FIELD max_attempts   ON {table} TYPE number      ASSERT $value != NONE;
     DEFINE FIELD attempts       ON {table} TYPE number      ASSERT $value != NONE;
     DEFINE FIELD priority       ON {table} TYPE number      ASSERT $value != NONE;
+    DEFINE FIELD unique_key     ON {table} TYPE string;
     DEFINE FIELD lease_time     ON {table} TYPE number      ASSERT $value != NONE;
     DEFINE FIELD payload        ON {table} FLEXIBLE TYPE object;
     DEFINE FIELD error_reason   ON {table} FLEXIBLE TYPE object;
@@ -68,7 +70,6 @@ async fn main() -> Result<()> {
     let cancellation_token = CancellationToken::new();
     let worker = Worker::new(
         Consumer::new().register(("send-email", |ctx: Context| async move {
-            dbg!(&ctx);
             let send_email: SendEmail = ctx.deserialize()?;
             dbg!(send_email.to, send_email.body);
             // Err(mq::Error::UnknownError("some error".into()))

--- a/mq-surreal/README.md
+++ b/mq-surreal/README.md
@@ -15,6 +15,7 @@ DEFINE FIELD kind           ON queue TYPE string      ASSERT $value != NONE;
 DEFINE FIELD max_attempts   ON queue TYPE number      ASSERT $value != NONE;
 DEFINE FIELD attempts       ON queue TYPE number      ASSERT $value != NONE;
 DEFINE FIELD priority       ON queue TYPE number      ASSERT $value != NONE;
+DEFINE FIELD unique_key     ON queue TYPE string;
 DEFINE FIELD lease_time     ON queue TYPE number      ASSERT $value != NONE;
 DEFINE FIELD payload        ON queue FLEXIBLE TYPE object;
 DEFINE FIELD error_reason   ON queue FLEXIBLE TYPE object;

--- a/mq/src/job.rs
+++ b/mq/src/job.rs
@@ -25,6 +25,7 @@ pub struct Job {
     lease_time: Duration,
     /// Higher priority will get polled first.
     priority: u8,
+    unique_key: Option<String>,
 }
 
 impl Job {
@@ -46,6 +47,7 @@ impl Job {
             max_attempts: 3,
             lease_time: Duration::from_secs(30),
             priority: 0,
+            unique_key: None,
         }
     }
 
@@ -149,6 +151,15 @@ impl Job {
 
     pub fn with_priority(mut self, priority: u8) -> Self {
         self.priority = priority;
+        self
+    }
+
+    pub fn unique_key(&self) -> &Option<String> {
+        &self.unique_key
+    }
+
+    pub fn with_unique_key(mut self, unique_key: Option<String>) -> Self {
+        self.unique_key = unique_key;
         self
     }
 }

--- a/mq/src/worker.rs
+++ b/mq/src/worker.rs
@@ -129,5 +129,4 @@ impl Worker {
 #[derive(Debug)]
 enum StreamSource {
     Polling,
-    Listener,
 }


### PR DESCRIPTION
This guarantees that no dupe messages can be published with the same key.