### PR TITLE
update surrealdb to v1.0.0-beta10

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Example
 
 ```toml
 [dependencies]
-mq = "0.4.3"
-mq-surreal = "v0.4.3"
+mq = "0.4.8"
+mq-surreal = "v0.4.8"
 tokio = { version = "1.27.0", features = ["full"] }
 ```
 
@@ -19,7 +19,7 @@ Refer to the examples on the usage.
 
 # Supported Backends
 
-* SurrealDB (requires v1.0.0-beta9+)
+* SurrealDB (requires v1.0.0-beta10+). For SurrealDB v1.0.0-beta9 use v0.4.8 version for mq.
 
 If you are interested in other backends feel free submit PR or features requests.
 

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -13,7 +13,7 @@ mq-surreal = { path = "../../mq-surreal", version = "0.4.8" }
 num_cpus = "1.15.0"
 serde = { version = "1.0.159", features = ["serde_derive"] }
 serde_json = "1.0.94"
-surrealdb = { version = "1.0.0-beta.9", features = ["kv-rocksdb"] }
+surrealdb = { version = "1.0.0-beta.10", features = ["kv-rocksdb"] }
 tokio = { version = "1.26.0", features = ["macros"] }
 tokio-util = "0.7.7"
 tracing = "0.1.37"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -5,6 +5,7 @@ use mq::{Consumer, Context, Job, JobResult, Producer, Worker};
 use mq_surreal::{SurrealJobProcessor, SurrealProducer};
 use serde::Deserialize;
 use serde_json::json;
+use surrealdb::dbs::Capabilities;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Deserialize, Debug)]
@@ -24,7 +25,9 @@ async fn main() -> Result<()> {
                 "file://{}/data.db",
                 std::env::current_dir().unwrap().to_string_lossy()
             ),
-            surrealdb::opt::Config::new().set_strict(true),
+            surrealdb::opt::Config::new()
+                .set_strict(true)
+                .capabilities(Capabilities::all()),
         ))
         .await?,
     );
@@ -40,20 +43,20 @@ async fn main() -> Result<()> {
     // create table schema for mq
     db.query(format!(
         r#"
-    DEFINE TABLE {table} SCHEMAFULL;
-    DEFINE FIELD created_at     ON {table} TYPE datetime    ASSERT $value != NONE;
-    DEFINE FIELD updated_at     ON {table} TYPE datetime    ASSERT $value != NONE;
-    DEFINE FIELD scheduled_at   ON {table} TYPE datetime    ASSERT $value != NONE;
-    DEFINE FIELD locked_at      ON {table} TYPE datetime;
-    DEFINE FIELD queue          ON {table} TYPE string      ASSERT $value != NONE;
-    DEFINE FIELD kind           ON {table} TYPE string      ASSERT $value != NONE;
-    DEFINE FIELD max_attempts   ON {table} TYPE number      ASSERT $value != NONE;
-    DEFINE FIELD attempts       ON {table} TYPE number      ASSERT $value != NONE;
-    DEFINE FIELD priority       ON {table} TYPE number      ASSERT $value != NONE;
-    DEFINE FIELD unique_key     ON {table} TYPE string;
-    DEFINE FIELD lease_time     ON {table} TYPE number      ASSERT $value != NONE;
-    DEFINE FIELD payload        ON {table} FLEXIBLE TYPE object;
-    DEFINE FIELD error_reason   ON {table} FLEXIBLE TYPE object;
+DEFINE TABLE {table} SCHEMAFULL;
+DEFINE FIELD created_at     ON {table} TYPE datetime;
+DEFINE FIELD updated_at     ON {table} TYPE datetime;
+DEFINE FIELD scheduled_at   ON {table} TYPE datetime;
+DEFINE FIELD locked_at      ON {table} TYPE option<datetime>;
+DEFINE FIELD queue          ON {table} TYPE string;
+DEFINE FIELD kind           ON {table} TYPE string;
+DEFINE FIELD max_attempts   ON {table} TYPE number;
+DEFINE FIELD attempts       ON {table} TYPE number;
+DEFINE FIELD priority       ON {table} TYPE number;
+DEFINE FIELD unique_key     ON {table} TYPE option<string>;
+DEFINE FIELD lease_time     ON {table} TYPE number;
+DEFINE FIELD payload        ON {table} FLEXIBLE TYPE object;
+DEFINE FIELD error_reason   ON {table} FLEXIBLE TYPE option<object>;
     "#
     ))
     .await?

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -19,7 +19,14 @@ async fn main() -> Result<()> {
 
     // connect to surrealdb
     let db = Arc::new(
-        surrealdb::engine::any::connect(("file://./data.db", surrealdb::opt::Strict)).await?,
+        surrealdb::engine::any::connect((
+            format!(
+                "file://{}/data.db",
+                std::env::current_dir().unwrap().to_string_lossy()
+            ),
+            surrealdb::opt::Config::new().set_strict(true),
+        ))
+        .await?,
     );
 
     // create surrealdb namespace and db

--- a/mq-surreal/Cargo.toml
+++ b/mq-surreal/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["job", "scheduler", "queue"]
 
 [dependencies]
 async-trait = "0.1.73"
-mq = { "path" = "../mq", version = "0.4.7" }
+mq = { "path" = "../mq", version = "0.4.8" }
 serde_json = "1.0.105"
-surrealdb = "1.0.0-beta.9"
+surrealdb = "1.0.0-beta.10"
 time = { version = "0.3.28", features = ["std", "serde"] }

--- a/mq-surreal/README.md
+++ b/mq-surreal/README.md
@@ -6,19 +6,19 @@
 
 ```sql
 DEFINE TABLE queue SCHEMAFULL;
-DEFINE FIELD created_at     ON queue TYPE datetime    ASSERT $value != NONE;
-DEFINE FIELD updated_at     ON queue TYPE datetime    ASSERT $value != NONE;
-DEFINE FIELD scheduled_at   ON queue TYPE datetime    ASSERT $value != NONE;
-DEFINE FIELD locked_at      ON queue TYPE datetime;
-DEFINE FIELD queue          ON queue TYPE string      ASSERT $value != NONE;
-DEFINE FIELD kind           ON queue TYPE string      ASSERT $value != NONE;
-DEFINE FIELD max_attempts   ON queue TYPE number      ASSERT $value != NONE;
-DEFINE FIELD attempts       ON queue TYPE number      ASSERT $value != NONE;
-DEFINE FIELD priority       ON queue TYPE number      ASSERT $value != NONE;
-DEFINE FIELD unique_key     ON queue TYPE string;
-DEFINE FIELD lease_time     ON queue TYPE number      ASSERT $value != NONE;
+DEFINE FIELD created_at     ON queue TYPE datetime;
+DEFINE FIELD updated_at     ON queue TYPE datetime;
+DEFINE FIELD scheduled_at   ON queue TYPE datetime;
+DEFINE FIELD locked_at      ON queue TYPE option<datetime>;
+DEFINE FIELD queue          ON queue TYPE string;
+DEFINE FIELD kind           ON queue TYPE string;
+DEFINE FIELD max_attempts   ON queue TYPE number;
+DEFINE FIELD attempts       ON queue TYPE number;
+DEFINE FIELD priority       ON queue TYPE number;
+DEFINE FIELD unique_key     ON queue TYPE option<string>;
+DEFINE FIELD lease_time     ON queue TYPE number;
 DEFINE FIELD payload        ON queue FLEXIBLE TYPE object;
-DEFINE FIELD error_reason   ON queue FLEXIBLE TYPE object;
+DEFINE FIELD error_reason   ON queue FLEXIBLE TYPE option<object>;
 ```
 
 Requires SurrealDB v1.0.0-beta9+

--- a/mq/src/worker.rs
+++ b/mq/src/worker.rs
@@ -116,7 +116,7 @@ impl Worker {
                                     handler.queue(),
                                     handler.kind(),
                                     &id,
-                                    json!(e.to_string()),
+                                    json!({ "error": e.to_string() }),
                                 )
                                 .await?;
                         }


### PR DESCRIPTION
* updated surrealdb to v1.0.0-beta10
* convert `time::OffsetDateTime` to `surrealdb::sql::Datetime` until surrealdb adds native `time` crate support. (might have perf impact)
* use `std::env::current_dir()` in example since relative path is broken for rocksdb.
* breaking changes:
  * prefer `option<T>` instead of nullable fields and remove ASSERT $value != NONE.
  * `error_reason` is inside `{ "error" : "....error_reason" }` so it confirms with object type.